### PR TITLE
meson.build: fix wcm version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('wcm', 'c', 'cpp', version : '0.3.1', default_options : 'cpp_std=c++17')
+project('wcm', 'c', 'cpp', version : '0.4.0', default_options : 'cpp_std=c++17')
 
 add_global_arguments('-DWAYFIRE_CONFIG_FILE="' + get_option('wayfire_config_file_path') + '"', language : 'cpp')
 add_global_arguments('-DWF_SHELL_CONFIG_FILE="' + get_option('wf_shell_config_file_path') + '"', language : 'cpp')


### PR DESCRIPTION
Wasn't updated for the most recent release.