### PR TITLE
adapt to new XML dynamic list format

### DIFF
--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -83,7 +83,7 @@ static Option *create_option(xmlNode *cur_node, Plugin *p)
         {
             o->type = OPTION_TYPE_KEY;
             o->default_value.s = strdup("");
-        } else if (std::string((char*)prop) == "dynamic_list")
+        } else if (std::string((char*)prop) == "dynamic-list")
         {
             o->type = OPTION_TYPE_DYNAMIC_LIST;
         } else


### PR DESCRIPTION
The autostart and command plugins are still hardcoded, and this PR does not really add support for dynamic lists. This should serve as an temporary solution until such support is implemented.

Tested with autostart and command, adding and removing items works.
