### PR TITLE
make buttons on main page be the same size (old behavior)

### DIFF
--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -832,6 +832,7 @@ MainPage::Category::Category(const Glib::ustring & name,
     vbox.set_margin_top(10);
     vbox.set_margin_bottom(10);
     flowbox.set_selection_mode(Gtk::SELECTION_NONE);
+    flowbox.set_halign(Gtk::ALIGN_START);
     flowbox.set_min_children_per_line(3);
 }
 


### PR DESCRIPTION
Makes all buttons be always the same size, but they won't fill all the available space (it worked like this before). I don't like it, but I cannot yet find a way to fix it without writing a lot of code to handle resizing.

### Screenshots

With `ALIGN_FILL` (current upstream version):
![view_2023-01-31_01-32-34](https://user-images.githubusercontent.com/50048443/215611308-6d54bfec-d4b7-46a1-b1d2-e49763675b4b.png)

![view_2023-01-31_01-35-21](https://user-images.githubusercontent.com/50048443/215611704-e77f00a7-b47a-4851-bf9f-790a95b127d5.png)


With `ALIGN_START` (this patch):
![view_2023-01-31_01-32-19](https://user-images.githubusercontent.com/50048443/215611465-176a83f5-9e2b-4ede-ab50-172deabc2d79.png)

![view_2023-01-31_01-35-36](https://user-images.githubusercontent.com/50048443/215611711-62d46160-4150-4872-9016-af82e35c73a6.png)

