### PR TITLE
Present window when wcm is run again

### DIFF
--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1166,6 +1166,8 @@ WCM::WCM(Glib::RefPtr<Gtk::Application> app)
         create_main_layout();
         window->show_all();
     });
+
+    app->signal_activate().connect([&] { wcm->window->present(); });
 }
 
 static void registry_add_object(void *data, struct wl_registry *registry,


### PR DESCRIPTION
When wcm is run while it is already running, nothing happened because it is single instance. Calling GtkWindow.present() gives wayfire an indication to raise the window, so it doesn't seem broken.