### PR TITLE
Unbreak build on FreeBSD 13.2

### DIFF
--- a/src/wcm.hpp
+++ b/src/wcm.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <gdk/gdkwayland.h>
 #include <gtkmm.h>
 #include <iostream>


### PR DESCRIPTION
Found via poudriere. FreeBSD 14.0 isn't affected due to shipping libc++ 16.