### PR TITLE
build: Bump the required wayfire version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('wcm', 'c', 'cpp', version : '0.9.0', default_options : 'cpp_std=c++17')
 add_global_arguments('-DWAYFIRE_CONFIG_FILE="' + get_option('wayfire_config_file_path') + '"', language : 'cpp')
 add_global_arguments('-DWF_SHELL_CONFIG_FILE="' + get_option('wf_shell_config_file_path') + '"', language : 'cpp')
 
-wayfire = dependency('wayfire')
+wayfire = dependency('wayfire', version: '>=0.9.0')
 wf_shell = dependency('wf-shell', required : get_option('wf_shell'))
 
 wayfire_metadata_dir = wayfire.get_variable(pkgconfig: 'metadatadir')


### PR DESCRIPTION
This is required for animation options to work correctly.