### PR TITLE
Fix missing categories

### DIFF
--- a/wayfire-config-manager.desktop
+++ b/wayfire-config-manager.desktop
@@ -4,4 +4,4 @@ Comment=Configure Wayfire Settings
 Exec=wcm
 Icon=wcm
 Type=Application
-Categories=Utility;
+Categories=Settings;DestkopSettings;Utility;


### PR DESCRIPTION
In LXQt it was not shown at all in `lxqt-config`, I think this goes for all menus.