### PR TITLE
Patch to add cli option for launching wcm directly to plugins. Resolves #93

### DIFF
--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1746,7 +1746,7 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
     compound->set_value_untyped(value);
 }
 
-Plugin*WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
+Plugin *WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
 {
     auto it = std::find_if(plugins.begin(), plugins.end(),
         [&search_name] (const Plugin *plugin)

--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1745,14 +1745,15 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
     compound->set_value_untyped(value);
 }
 
-Plugin* WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
+Plugin*WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
 {
     auto it = std::find_if(plugins.begin(), plugins.end(),
         [&search_name](const Plugin* plugin) {
             return plugin->name == search_name; // Compare the plugin name
         });
 
-    if (it != plugins.end()) {
+    if (it != plugins.end()) 
+    {
         return *it; // Return the found Plugin pointer
     }
     std::cout << "plugin not found, name invalid" << std::endl;

--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1584,8 +1584,8 @@ void WCM::create_main_layout()
     window->add(global_layout);
     if (!start_plugin.empty())
     {
-        Plugin* launch_plugin = find_plugin_by_name(plugins,start_plugin);
-        std::cout << "Opening Plugin: " << start_plugin << std::endl; 
+        Plugin* launch_plugin = find_plugin_by_name(plugins, start_plugin);
+        std::cout << "Opening Plugin: " << start_plugin << std::endl;
         this->open_page(launch_plugin);
     }
 }
@@ -1749,7 +1749,7 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
 Plugin*WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
 {
     auto it = std::find_if(plugins.begin(), plugins.end(),
-        [&search_name](const Plugin* plugin)
+        [&search_name] (const Plugin* plugin)
     {
         return plugin->name == search_name; // Compare the plugin name
     });

--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1582,11 +1582,12 @@ void WCM::create_main_layout()
     global_layout.pack_start(left_stack, false, false);
     global_layout.pack_start(main_stack, true, true);
     window->add(global_layout);
-    if (!start_plugin.empty()) {
-	    Plugin* launch_plugin = find_plugin_by_name(plugins,start_plugin);
-	    std::cout << "Opening Plugin: " << start_plugin << std::endl; 
-	    this->open_page(launch_plugin);
-	}
+    if (!start_plugin.empty())
+    {
+        Plugin* launch_plugin = find_plugin_by_name(plugins,start_plugin);
+        std::cout << "Opening Plugin: " << start_plugin << std::endl; 
+        this->open_page(launch_plugin);
+    }
 }
 
 void WCM::open_page(Plugin *plugin)
@@ -1748,17 +1749,20 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
 Plugin*WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
 {
     auto it = std::find_if(plugins.begin(), plugins.end(),
-        [&search_name](const Plugin* plugin) {
-            return plugin->name == search_name; // Compare the plugin name
-        });
+        [&search_name](const Plugin* plugin)
+    {
+        return plugin->name == search_name; // Compare the plugin name
+    });
 
-    if (it != plugins.end()) 
+    if (it != plugins.end())
     {
         return *it; // Return the found Plugin pointer
     }
+
     std::cout << "plugin not found, name invalid" << std::endl;
     return nullptr; // Return nullptr if not found
 }
+
 /**
  * Save the given configuration to the given file.
  *

--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1584,7 +1584,7 @@ void WCM::create_main_layout()
     window->add(global_layout);
     if (!start_plugin.empty())
     {
-        Plugin* launch_plugin = find_plugin_by_name(plugins, start_plugin);
+        Plugin *launch_plugin = find_plugin_by_name(plugins, start_plugin);
         std::cout << "Opening Plugin: " << start_plugin << std::endl;
         this->open_page(launch_plugin);
     }
@@ -1749,7 +1749,7 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
 Plugin*WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
 {
     auto it = std::find_if(plugins.begin(), plugins.end(),
-        [&search_name] (const Plugin* plugin)
+        [&search_name] (const Plugin *plugin)
     {
         return plugin->name == search_name; // Compare the plugin name
     });

--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1309,6 +1309,11 @@ WCM::WCM(Glib::RefPtr<Gtk::Application> app)
         wf_shell_config_file = value;
         return true;
     }, "shell-config", 's', "wf-shell config file to use", "file");
+    app->add_main_option_entry([this] (const Glib::ustring &, const Glib::ustring & value, bool)
+    {
+        start_plugin = value;
+        return true;
+    }, "plugin", 'p', "plugin to open at launch, or none for default", "name");
 
     app->signal_startup().connect([this, app] ()
     {
@@ -1577,6 +1582,11 @@ void WCM::create_main_layout()
     global_layout.pack_start(left_stack, false, false);
     global_layout.pack_start(main_stack, true, true);
     window->add(global_layout);
+    if (!start_plugin.empty()) {
+	    Plugin* launch_plugin = find_plugin_by_name(plugins,start_plugin);
+	    std::cout << "Opening Plugin: " << start_plugin << std::endl; 
+	    this->open_page(launch_plugin);
+	}
 }
 
 void WCM::open_page(Plugin *plugin)
@@ -1735,6 +1745,19 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
     compound->set_value_untyped(value);
 }
 
+Plugin* WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
+{
+    auto it = std::find_if(plugins.begin(), plugins.end(),
+        [&search_name](const Plugin* plugin) {
+            return plugin->name == search_name; // Compare the plugin name
+        });
+
+    if (it != plugins.end()) {
+        return *it; // Return the found Plugin pointer
+    }
+    std::cout << "plugin not found, name invalid" << std::endl;
+    return nullptr; // Return nullptr if not found
+}
 /**
  * Save the given configuration to the given file.
  *

--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -1746,7 +1746,7 @@ void update_compound_from_section(wf::config::compound_option_t *compound,
     compound->set_value_untyped(value);
 }
 
-Plugin *WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
+Plugin*WCM::find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name)
 {
     auto it = std::find_if(plugins.begin(), plugins.end(),
         [&search_name] (const Plugin *plugin)

--- a/src/wcm.hpp
+++ b/src/wcm.hpp
@@ -314,6 +314,7 @@ class WCM
     wf::config::config_manager_t wf_shell_config_mgr;
     std::string wf_config_file;
     std::string wf_shell_config_file;
+    std::string start_plugin;
     std::vector<Plugin*> plugins;
 
     Plugin *current_plugin = nullptr;
@@ -395,4 +396,5 @@ class WCM
 
     bool lock_input(Gtk::Dialog *grab_dialog);
     void unlock_input();
+    Plugin* find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name);
 };

--- a/src/wcm.hpp
+++ b/src/wcm.hpp
@@ -396,5 +396,5 @@ class WCM
 
     bool lock_input(Gtk::Dialog *grab_dialog);
     void unlock_input();
-    Plugin* find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name);
+    Plugin *find_plugin_by_name(std::vector<Plugin*> plugins, std::string search_name);
 };


### PR DESCRIPTION
This adds a new commandline option -p which you can feed a plugin name. e.g wcm -p input and it will launch wcm directly to the input plugin page. This allows us to integrate mate-control-center directly with WCM.