### PR TITLE
Get rid of redundant wdisplays subproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subprojects/wdisplays"]
-	path = subprojects/wdisplays
-	url = https://github.com/artizirk/wdisplays

--- a/meson.build
+++ b/meson.build
@@ -28,10 +28,6 @@ evdev = dependency('libevdev')
 
 add_project_arguments('-DICONDIR="' + icon_dir + '"', language : 'cpp')
 
-if get_option('enable_wdisplays') == true
-    wdisplays = subproject('wdisplays')
-endif
-
 subdir('icons')
 subdir('proto')
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('wf_shell', type: 'feature', value: 'auto', description: 'Build with wf-shell support')
 option('wayfire_config_file_path', type : 'string', value : '~/.config/wayfire.ini', description : 'Full path of wayfire config file')
 option('wf_shell_config_file_path', type : 'string', value : '~/.config/wf-shell.ini', description : 'Full path of wf-shell config file')
-option('enable_wdisplays', type : 'boolean', value : 'false', description : 'Build wdisplays')
+


### PR DESCRIPTION
as discussed in #98 this completes the removal of the wdisplays bundling
people are encouraged to [grab wdisplays from elsewhere such as this repository and other forks](https://github.com/artizirk/wdisplays)
this also closes #97 
packagers should mark wdisplays as a optional dependency rather than a dependency since its still a supported option in wcm.