### PR TITLE
build: Install wcm.svg to the expected location

### DIFF
--- a/icons/desktop/meson.build
+++ b/icons/desktop/meson.build
@@ -1,2 +1,1 @@
-install_data('wcm.svg', install_dir: join_paths(share_dir, 'icons'))
-install_data('wcm.svg', install_dir: join_paths(share_dir, 'wcm', 'icons'))
+install_data('wcm.svg', install_dir: join_paths(share_dir, 'icons', 'hicolor', 'scalable', 'apps'))

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ wayfire_sysconf_dir = wayfire.get_variable(pkgconfig: 'sysconfdir')
 
 share_dir = join_paths(get_option('prefix'), 'share')
 wayfire_locale_dir = join_paths(share_dir, 'locale')
-wcm_icon_dir = join_paths(share_dir, 'wcm', 'icons')
+wcm_icon_dir = join_paths(share_dir, 'icons', 'hicolor', 'scalable', 'apps')
 wayfire_icon_dir = wayfire.get_variable(pkgconfig: 'icondir')
 
 add_global_arguments('-DWAYFIRE_METADATADIR="' + wayfire_metadata_dir + '"', language : 'cpp')


### PR DESCRIPTION
Install wcm.svg to $prefix/share/icons/hicolor/scalable/apps/ directory.

Fixes #117.