### PR TITLE
Fix internationalisation

### DIFF
--- a/src/wcm.cpp
+++ b/src/wcm.cpp
@@ -2,7 +2,7 @@
 #include "utils.hpp"
 
 #include <filesystem>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <libevdev/libevdev.h>
 #include <libintl.h>
 #include <wayfire/config/compound-option.hpp>

--- a/src/wcm.hpp
+++ b/src/wcm.hpp
@@ -31,7 +31,6 @@
 #include <gdk/gdkwayland.h>
 #include <gtkmm.h>
 #include <iostream>
-#include <fmt/core.h>
 #include <libintl.h>
 #include <variant>
 #include <vector>


### PR DESCRIPTION
fmt::format requires fmt/format.h not fmt/core.h as of libfmt version 11.

fmt/core.h includes only basic functionality now.

Fixes 8bf4c480256cba4789fd33920d29996fbdf91f52