### PR TITLE
Install icons into private directory

### DIFF
--- a/icons/desktop/meson.build
+++ b/icons/desktop/meson.build
@@ -1,1 +1,2 @@
 install_data('wcm.svg', install_dir: join_paths(share_dir, 'icons', 'hicolor', 'scalable', 'apps'))
+install_data('wcm.svg', install_dir: join_paths(share_dir, 'wcm', 'icons'))

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ wayfire_sysconf_dir = wayfire.get_variable(pkgconfig: 'sysconfdir')
 
 share_dir = join_paths(get_option('prefix'), 'share')
 wayfire_locale_dir = join_paths(share_dir, 'locale')
-wcm_icon_dir = join_paths(share_dir, 'icons', 'hicolor', 'scalable', 'apps')
+wcm_icon_dir = join_paths(share_dir, 'wcm', 'icons')
 wayfire_icon_dir = wayfire.get_variable(pkgconfig: 'icondir')
 
 add_global_arguments('-DWAYFIRE_METADATADIR="' + wayfire_metadata_dir + '"', language : 'cpp')


### PR DESCRIPTION
The icons `plugin-*` have too generic name, and may conflict with other packages on the system. Move them back to the
`$prefix/share/wcm/icons/` directory to avoid possible collision.

This partially reverts commit 84063a07ccfc5be2a96b98d934271761a1730c2b